### PR TITLE
Issue 1 mutex

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -11,10 +11,10 @@ import (
 type ConsumeHandler interface {
 	// Handle is called when a message is received when polling SQS.
 	Handle(message *sqs.Message, deadline ExtendTimeout) error
-	
+
 	// Error handles any errors returned from Handle(...). The param
 	// messageHandled is true if Handle(...) returned an error, false if
-	// the message was handled but an error was encountered performing 
+	// the message was handled but an error was encountered performing
 	// queue operations. (SQS DeleteMessage)
 	Error(message *sqs.Message, messageHandled bool, err error)
 }


### PR DESCRIPTION
#1 

i fixed race condition in consumer_test.go

result:
```
$ go test -v -race ./...
=== RUN   TestNewConsumer
=== RUN   TestNewConsumer/New
=== RUN   TestNewConsumer/QueueDoesNotExist
=== RUN   TestNewConsumer/UnknownErrorGetQueueURL
=== RUN   TestNewConsumer/Config
=== RUN   TestNewConsumer/MultipleConfig
--- PASS: TestNewConsumer (0.00s)
    --- PASS: TestNewConsumer/New (0.00s)
    --- PASS: TestNewConsumer/QueueDoesNotExist (0.00s)
    --- PASS: TestNewConsumer/UnknownErrorGetQueueURL (0.00s)
    --- PASS: TestNewConsumer/Config (0.00s)
    --- PASS: TestNewConsumer/MultipleConfig (0.00s)
=== RUN   TestConsumer_Start
=== RUN   TestConsumer_Start/1m1w
=== RUN   TestConsumer_Start/3m1w
=== RUN   TestConsumer_Start/3m2w_ProcessingTime
=== RUN   TestConsumer_Start/ReceiveMessage_Error
=== RUN   TestConsumer_Start/NoMessages
=== RUN   TestConsumer_Start/MaxBatchSize_MaxWorkers
=== RUN   TestConsumer_Start/Stop_NoMessages
=== RUN   TestConsumer_Start/Stop_UnreadMessages
=== RUN   TestConsumer_Start/Stop_UnreadMessages_2
--- PASS: TestConsumer_Start (23.83s)
    --- PASS: TestConsumer_Start/1m1w (5.00s)
    --- PASS: TestConsumer_Start/3m1w (5.00s)
    --- PASS: TestConsumer_Start/3m2w_ProcessingTime (7.31s)
    --- PASS: TestConsumer_Start/ReceiveMessage_Error (0.00s)
    --- PASS: TestConsumer_Start/NoMessages (1.00s)
    --- PASS: TestConsumer_Start/MaxBatchSize_MaxWorkers (1.00s)
    --- PASS: TestConsumer_Start/Stop_NoMessages (1.01s)
    --- PASS: TestConsumer_Start/Stop_UnreadMessages (1.00s)
    --- PASS: TestConsumer_Start/Stop_UnreadMessages_2 (2.50s)
=== RUN   TestConsumer_consume
=== RUN   TestConsumer_consume/Success
=== RUN   TestConsumer_consume/HandlerHandle_Error
=== RUN   TestConsumer_consume/DeleteMessage_Error
--- PASS: TestConsumer_consume (0.00s)
    --- PASS: TestConsumer_consume/Success (0.00s)
    --- PASS: TestConsumer_consume/HandlerHandle_Error (0.00s)
    --- PASS: TestConsumer_consume/DeleteMessage_Error (0.00s)
=== RUN   TestConsumer_extendDeadline
=== RUN   TestConsumer_extendDeadline/Success
=== RUN   TestConsumer_extendDeadline/Error
--- PASS: TestConsumer_extendDeadline (0.00s)
    --- PASS: TestConsumer_extendDeadline/Success (0.00s)
    --- PASS: TestConsumer_extendDeadline/Error (0.00s)
=== RUN   TestNewPublisher
=== RUN   TestNewPublisher/New
=== RUN   TestNewPublisher/QueueDoesNotExist
=== RUN   TestNewPublisher/UnknownErrorGetQueueURL
=== RUN   TestNewPublisher/Config
=== RUN   TestNewPublisher/MultipleConfig
--- PASS: TestNewPublisher (0.00s)
    --- PASS: TestNewPublisher/New (0.00s)
    --- PASS: TestNewPublisher/QueueDoesNotExist (0.00s)
    --- PASS: TestNewPublisher/UnknownErrorGetQueueURL (0.00s)
    --- PASS: TestNewPublisher/Config (0.00s)
    --- PASS: TestNewPublisher/MultipleConfig (0.00s)
=== RUN   TestPubImpl_Stop
--- PASS: TestPubImpl_Stop (0.00s)
=== RUN   TestPubImpl_Start
=== RUN   TestPubImpl_Start/TriggerMaxSQSBatchSize
=== RUN   TestPubImpl_Start/TriggerBatchWindow
=== RUN   TestPubImpl_Start/TriggerStop
=== RUN   TestPubImpl_Start/TriggerAll
--- PASS: TestPubImpl_Start (1.51s)
    --- PASS: TestPubImpl_Start/TriggerMaxSQSBatchSize (0.00s)
        publisher_test.go:172: publishBatchFn: 10 messages
    --- PASS: TestPubImpl_Start/TriggerBatchWindow (0.01s)
        publisher_test.go:198: publishBatchFn: 3 messages
    --- PASS: TestPubImpl_Start/TriggerStop (0.00s)
        publisher_test.go:223: publishBatchFn: 5 messages
    --- PASS: TestPubImpl_Start/TriggerAll (1.50s)
        publisher_test.go:252: SQSBatchSize: 10
        publisher_test.go:255: Timeout: 5
        publisher_test.go:265: Stop: 3
=== RUN   TestPubImpl_Publish
=== RUN   TestPubImpl_Publish/ErrInvalidMessage
=== RUN   TestPubImpl_Publish/OK
=== RUN   TestPubImpl_Publish/Error
=== RUN   TestPubImpl_Publish/NilConfig
--- PASS: TestPubImpl_Publish (0.00s)
    --- PASS: TestPubImpl_Publish/ErrInvalidMessage (0.00s)
    --- PASS: TestPubImpl_Publish/OK (0.00s)
    --- PASS: TestPubImpl_Publish/Error (0.00s)
    --- PASS: TestPubImpl_Publish/NilConfig (0.00s)
=== RUN   TestPubImpl_publishBatch
=== RUN   TestPubImpl_publishBatch/SuccessFailure
=== RUN   TestPubImpl_publishBatch/SendMessageBatchError
=== RUN   TestPubImpl_publishBatch/JsonError
--- PASS: TestPubImpl_publishBatch (0.31s)
    --- PASS: TestPubImpl_publishBatch/SuccessFailure (0.10s)
    --- PASS: TestPubImpl_publishBatch/SendMessageBatchError (0.10s)
    --- PASS: TestPubImpl_publishBatch/JsonError (0.10s)
PASS
ok  	github.com/sharonjl/sqsx	26.693s
```